### PR TITLE
fix: when skip_unchanged_digest is set the image is built twice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ RUN wget -O /kaniko/jq \
     chmod +x /kaniko/jq && \
     wget -O /kaniko/reg \
     https://github.com/genuinetools/reg/releases/download/v0.16.1/reg-linux-386 && \
-    chmod +x /kaniko/reg
+    chmod +x /kaniko/reg && \
+    wget -O /crane.tar.gz \ 
+    https://github.com/google/go-containerregistry/releases/download/v0.1.1/go-containerregistry_Linux_x86_64.tar.gz && \
+    tar -xvzf /crane.tar.gz crane -C /kaniko && \
+    rm crane.tar.gz
 
 COPY entrypoint.sh /
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ export DOCKERFILE="--dockerfile $CONTEXT_PATH/${INPUT_BUILD_FILE:-Dockerfile}"
 export TARGET=${INPUT_TARGET:+"--target=$INPUT_TARGET"}
 
 if [ ! -z $INPUT_SKIP_UNCHANGED_DIGEST ]; then
-    export DESTINATION="--no-push --digest-file digest"
+    export DESTINATION="--digest-file digest --tarPath image.tar --destination $IMAGE"
 else
     export DESTINATION="--destination $IMAGE"
     if [ ! -z $IMAGE_LATEST ]; then
@@ -101,16 +101,15 @@ if [ ! -z $INPUT_SKIP_UNCHANGED_DIGEST ]; then
         exit 0
     fi
 
-    export DESTINATION="--destination $IMAGE"
-    if [ ! -z $IMAGE_LATEST ]; then
-        export DESTINATION="$DESTINATION --destination $IMAGE_LATEST"  
-    fi
-    
-    export ARGS="$CACHE $CONTEXT $DOCKERFILE $TARGET $DESTINATION $INPUT_EXTRA_ARGS"
-
     echo "Pushing image..."
 
-    /kaniko/executor --reproducible $ARGS >/dev/null 2>&1
+    /kaniko/crane auth login $REGISTRY -u $USERNAME -p $PASSWORD
+    /kaniko/crane push image.tar $IMAGE
 
+    if [ ! -z $IMAGE_LATEST ]; then
+        echo "Tagging latest..."
+        /kaniko/crane tag $IMAGE latest  
+    fi
+ 
     echo "Done 🎉️"
 fi


### PR DESCRIPTION
This commit saves the image to tar file and then push it with crane tool