### PR TITLE
Honor tag_with_latest correctly

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,9 +10,12 @@ export TAG=${TAG#$INPUT_STRIP_TAG_PREFIX}
 export USERNAME=${INPUT_USERNAME:-$GITHUB_ACTOR}
 export PASSWORD=${INPUT_PASSWORD:-$GITHUB_TOKEN}
 export REPOSITORY=$IMAGE
-export IMAGE_LATEST=${INPUT_TAG_WITH_LATEST:+"$IMAGE:latest"}
 export IMAGE=$IMAGE:$TAG
 export CONTEXT_PATH=${INPUT_PATH}
+
+if [[ "$INPUT_TAG_WITH_LATEST" == "true" ]]; then
+    export IMAGE_LATEST="$IMAGE:latest"
+fi
 
 function ensure() {
     if [ -z "${1}" ]; then


### PR DESCRIPTION
First, thanks a lot for this action, it has saved me a lot of time to be able to use kaniko in GH actions

While using it, I noticed that tag_with_latest was not honored due to how the input variable was handled.

Whether it was set to false or true, latest was always being tagged

This PR fixes it, probably not in the most bash-fu way though