### PR TITLE
fix: IFS kaniko args containing spaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine as certs
 
 RUN apk --update add ca-certificates
 
-FROM gcr.io/kaniko-project/executor:v1.7.0-debug
+FROM gcr.io/kaniko-project/executor:v1.9.1-debug
 
 SHELL ["/busybox/sh", "-c"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,6 +75,9 @@ else
     fi
 fi
 
+# https://github.com/GoogleContainerTools/kaniko/issues/1803
+export IFS=''
+
 export ARGS="$CACHE $CONTEXT $DOCKERFILE $TARGET $DESTINATION $INPUT_EXTRA_ARGS"
 
 cat <<EOF >/kaniko/.docker/config.json
@@ -88,11 +91,11 @@ cat <<EOF >/kaniko/.docker/config.json
 }
 EOF
 
-# https://github.com/GoogleContainerTools/kaniko/issues/1803
-export IFS=''
-
 # https://github.com/GoogleContainerTools/kaniko/issues/1349
-/kaniko/executor --reproducible --force $ARGS
+# https://github.com/GoogleContainerTools/kaniko/issues/1803
+kaniko_cmd="/kaniko/executor ${ARGS} --reproducible --force"
+echo "Running kaniko command ${kaniko_cmd}"
+eval "${kaniko_cmd}"
 
 if [ ! -z $INPUT_SKIP_UNCHANGED_DIGEST ]; then
     export DIGEST=$(cat digest)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,6 +88,9 @@ cat <<EOF >/kaniko/.docker/config.json
 }
 EOF
 
+# https://github.com/GoogleContainerTools/kaniko/issues/1803
+export IFS=''
+
 # https://github.com/GoogleContainerTools/kaniko/issues/1349
 /kaniko/executor --reproducible --force $ARGS
 


### PR DESCRIPTION
This pr fix the problem of Kaniko build args that are containing spaces.

I.e args like that `--build-arg=JAVA_OPTIONS='-Dfoo=bar -Dfoo2=bar2'`

C.f: https://github.com/GoogleContainerTools/kaniko/issues/1803
