### PR TITLE
fix: only add seperator for non-empty ghcr image

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,11 +36,12 @@ ensure "${CONTEXT_PATH}" "path"
 
 if [ "$REGISTRY" == "ghcr.io" ]; then
     IMAGE_NAMESPACE="$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
-    export IMAGE="$IMAGE_NAMESPACE/$IMAGE"
-    export REPOSITORY="$IMAGE_NAMESPACE/$REPOSITORY"
+    [ -n "$REPOSITORY" ] && SEPERATOR="/"
+    export IMAGE="$IMAGE_NAMESPACE$SEPERATOR$IMAGE"
+    export REPOSITORY="$IMAGE_NAMESPACE$SEPERATOR$REPOSITORY"
 
     if [ ! -z $IMAGE_LATEST ]; then
-        export IMAGE_LATEST="$IMAGE_NAMESPACE/$IMAGE_LATEST"
+        export IMAGE_LATEST="$IMAGE_NAMESPACE$SEPERATOR$IMAGE_LATEST"
     fi
 
     if [ ! -z $INPUT_CACHE_REGISTRY ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,8 @@ ensure "${CONTEXT_PATH}" "path"
 
 if [ "$REGISTRY" == "ghcr.io" ]; then
     IMAGE_NAMESPACE="$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
-    [ -n "$REPOSITORY" ] && SEPERATOR="/"
+    # Set `/` separator, unless image is pre-fixed with dash or slash
+    [ -n "$REPOSITORY" ] && [[ ! "$REPOSITORY" =~ ^[-/] ]] && SEPERATOR="/"
     export IMAGE="$IMAGE_NAMESPACE$SEPERATOR$IMAGE"
     export REPOSITORY="$IMAGE_NAMESPACE$SEPERATOR$REPOSITORY"
 


### PR DESCRIPTION
Closes #49 

In the case of not specifying an image (i. e. `image: ""`), the `/` seperator between repository and image will not be added.
This is useful when you want to keep your image repository to the same as the GitHub repo, without further post-fixing.