### PR TITLE
feat: output built image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,9 @@ with:
 ```
 
 for the tag `pre-0.1` will push `kaniko:0.1`, as the `pre-` part will be stripped from the tag name.
+
+## Outputs
+
+### `image`
+
+Full reference to the built image with registry and tag.

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,9 @@ inputs:
   debug:
     description: Enables trace for entrypoint.sh
     required: false
+outputs:
+  image:
+    description: "Full reference to the built image with registry and tag"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,6 +90,7 @@ EOF
 
 # https://github.com/GoogleContainerTools/kaniko/issues/1349
 /kaniko/executor --reproducible --force $ARGS
+echo "image=$IMAGE" >> $GITHUB_OUTPUT
 
 if [ ! -z $INPUT_SKIP_UNCHANGED_DIGEST ]; then
     export DIGEST=$(cat digest)


### PR DESCRIPTION
Closes #50

example of usage:
```
      - id: build
        uses: mnacharov/action-kaniko@master
        with:
          image: mnacharov/hello
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_PASSWORD }}
      - uses: azure/setup-kubectl@v3.2
        with:
          version: 'v1.24.8'
      - run: kubectl patch --local -f k8s/hello.Deployment.yaml -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"app\",\"image\":\"${{steps.build.outputs.image}}\"}]}}}}" -o yaml > k8s/hello.Deployment.yaml.new
      - run: mv -f  k8s/hello.Deployment.yaml.new  k8s/hello.Deployment.yaml
      - run: git commit -am "Update hello to $GITHUB_REF"
      - run: git push
```