### PR TITLE
Improve general robustness of entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine as certs
 
 RUN apk --update add ca-certificates
 
-FROM gcr.io/kaniko-project/executor:v1.9.1-debug
+FROM gcr.io/kaniko-project/executor:v1.12.1-debug
 
 SHELL ["/busybox/sh", "-c"]
 
@@ -13,7 +13,7 @@ RUN wget -O /kaniko/jq \
     https://github.com/genuinetools/reg/releases/download/v0.16.1/reg-linux-386 && \
     chmod +x /kaniko/reg && \
     wget -O /crane.tar.gz \ 
-    https://github.com/google/go-containerregistry/releases/download/v0.8.0/go-containerregistry_Linux_x86_64.tar.gz && \
+    https://github.com/google/go-containerregistry/releases/download/v0.15.2/go-containerregistry_Linux_x86_64.tar.gz && \
     tar -xvzf /crane.tar.gz crane -C /kaniko && \
     rm /crane.tar.gz
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,26 +1,26 @@
 #!/busybox/sh
 set -e pipefail
-if [[ "$INPUT_DEBUG" == "true" ]]; then
+if [ "$INPUT_DEBUG" = "true" ]; then
     set -o xtrace
 fi
 
-export REGISTRY=${INPUT_REGISTRY:-"docker.io"}
-export IMAGE=${INPUT_IMAGE}
-export BRANCH=$(echo ${GITHUB_REF} | sed -E "s/refs\/(heads|tags)\///g" | sed -e "s/\//-/g")
+export REGISTRY="${INPUT_REGISTRY:-"docker.io"}"
+export IMAGE="${INPUT_IMAGE}"
+export BRANCH="$(echo ${GITHUB_REF} | sed -E 's#refs/(heads|tags)/##g' | sed -e 's#/#-#g')"
 export TAG=${INPUT_TAG:-$([ "$BRANCH" == "master" ] && echo latest || echo $BRANCH)}
-export TAG=${TAG:-"latest"}
-export TAG=${TAG#$INPUT_STRIP_TAG_PREFIX}
-export USERNAME=${INPUT_USERNAME:-$GITHUB_ACTOR}
-export PASSWORD=${INPUT_PASSWORD:-$GITHUB_TOKEN}
-export REPOSITORY=$IMAGE
-export IMAGE=$IMAGE:$TAG
-export CONTEXT_PATH=${INPUT_PATH}
+export TAG="${TAG:-'latest'}"
+export TAG="${TAG#"$INPUT_STRIP_TAG_PREFIX"}"
+export USERNAME="${INPUT_USERNAME:-"$GITHUB_ACTOR"}"
+export PASSWORD="${INPUT_PASSWORD:-"$GITHUB_TOKEN"}"
+export REPOSITORY="${IMAGE}"
+export IMAGE="${IMAGE}:${TAG}"
+export CONTEXT_PATH="${INPUT_PATH}"
 
-if [[ "$INPUT_TAG_WITH_LATEST" == "true" ]]; then
-    export IMAGE_LATEST="$REPOSITORY:latest"
+if [ "$INPUT_TAG_WITH_LATEST" = "true" ]; then
+    export IMAGE_LATEST="${REPOSITORY}:latest"
 fi
 
-function ensure() {
+ensure() {
     if [ -z "${1}" ]; then
         echo >&2 "Unable to find the ${2} variable. Did you set with.${2}?"
         exit 1
@@ -34,48 +34,49 @@ ensure "${IMAGE}" "image"
 ensure "${TAG}" "tag"
 ensure "${CONTEXT_PATH}" "path"
 
-if [ "$REGISTRY" == "ghcr.io" ]; then
-    IMAGE_NAMESPACE="$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
-    export IMAGE="$IMAGE_NAMESPACE/$IMAGE"
-    export REPOSITORY="$IMAGE_NAMESPACE/$REPOSITORY"
+if [ "${REGISTRY}" = "ghcr.io" ]; then
+    IMAGE_NAMESPACE="$(echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]')"
+    export IMAGE="${IMAGE_NAMESPACE}/${IMAGE}"
+    export REPOSITORY="${IMAGE_NAMESPACE}/${REPOSITORY}"
 
-    if [ ! -z $IMAGE_LATEST ]; then
-        export IMAGE_LATEST="$IMAGE_NAMESPACE/$IMAGE_LATEST"
+    if [ -n "${IMAGE_LATEST}" ]; then
+        export IMAGE_LATEST="${IMAGE_NAMESPACE}/${IMAGE_LATEST}"
     fi
 
-    if [ ! -z $INPUT_CACHE_REGISTRY ]; then
-        export INPUT_CACHE_REGISTRY="$REGISTRY/$IMAGE_NAMESPACE/$INPUT_CACHE_REGISTRY"
+    if [ -n "${INPUT_CACHE_REGISTRY}" ]; then
+        export INPUT_CACHE_REGISTRY="${REGISTRY}/${IMAGE_NAMESPACE}/${INPUT_CACHE_REGISTRY}"
     fi
 fi
 
-if [ "$REGISTRY" == "docker.io" ]; then
+if [ "${REGISTRY}" = "docker.io" ]; then
     export REGISTRY="index.${REGISTRY}/v1/"
 else
-    export IMAGE="$REGISTRY/$IMAGE"
+    export IMAGE="${REGISTRY}/${IMAGE}"
 
-    if [ ! -z $IMAGE_LATEST ]; then
-        export IMAGE_LATEST="$REGISTRY/$IMAGE_LATEST"
+    if [ -n "${IMAGE_LATEST}" ]; then
+        export IMAGE_LATEST="${REGISTRY}/${IMAGE_LATEST}"
     fi
 fi
 
-export CACHE=${INPUT_CACHE:+"--cache=true"}
-export CACHE=$CACHE${INPUT_CACHE_TTL:+" --cache-ttl=$INPUT_CACHE_TTL"}
-export CACHE=$CACHE${INPUT_CACHE_REGISTRY:+" --cache-repo=$INPUT_CACHE_REGISTRY"}
-export CACHE=$CACHE${INPUT_CACHE_DIRECTORY:+" --cache-dir=$INPUT_CACHE_DIRECTORY"}
-export CONTEXT="--context $GITHUB_WORKSPACE/$CONTEXT_PATH"
-export DOCKERFILE="--dockerfile $CONTEXT_PATH/${INPUT_BUILD_FILE:-Dockerfile}"
-export TARGET=${INPUT_TARGET:+"--target=$INPUT_TARGET"}
+export CACHE="${INPUT_CACHE:+"--cache=true"}"
+export CACHE="${CACHE}${INPUT_CACHE_TTL:+" --cache-ttl=$INPUT_CACHE_TTL"}"
+export CACHE="${CACHE}${INPUT_CACHE_REGISTRY:+" --cache-repo=$INPUT_CACHE_REGISTRY"}"
+export CACHE="${CACHE}${INPUT_CACHE_DIRECTORY:+" --cache-dir=$INPUT_CACHE_DIRECTORY"}"
+export CONTEXT="--context ${GITHUB_WORKSPACE}/${CONTEXT_PATH}"
+export DOCKERFILE="--dockerfile ${CONTEXT_PATH}/${INPUT_BUILD_FILE:-Dockerfile}"
+export TARGET="${INPUT_TARGET:+"--target=$INPUT_TARGET"}"
+export ARG_DIGEST="--digest-file /kaniko/digest --image-name-tag-with-digest-file=/kaniko/image-tag-digest"
 
-if [ ! -z $INPUT_SKIP_UNCHANGED_DIGEST ]; then
-    export DESTINATION="--digest-file digest --no-push --tarPath image.tar --destination $IMAGE"
+if [ -n "${INPUT_SKIP_UNCHANGED_DIGEST}" ]; then
+    export DESTINATION="--no-push --tarPath image.tar --destination ${IMAGE}"
 else
     export DESTINATION="--destination $IMAGE"
-    if [ ! -z $IMAGE_LATEST ]; then
-        export DESTINATION="$DESTINATION --destination $IMAGE_LATEST"  
+    if [ -n "${IMAGE_LATEST}" ]; then
+        export DESTINATION="${DESTINATION} --destination ${IMAGE_LATEST}"  
     fi
 fi
 
-export ARGS="$CACHE $CONTEXT $DOCKERFILE $TARGET $DESTINATION $INPUT_EXTRA_ARGS"
+export ARGS="${CACHE} ${CONTEXT} ${DOCKERFILE} ${TARGET} ${ARG_DIGEST} ${DESTINATION} ${INPUT_EXTRA_ARGS}"
 
 cat <<EOF >/kaniko/.docker/config.json
 {
@@ -89,29 +90,29 @@ cat <<EOF >/kaniko/.docker/config.json
 EOF
 
 # https://github.com/GoogleContainerTools/kaniko/issues/1349
-/kaniko/executor --reproducible --force $ARGS
+/kaniko/executor --reproducible --force ${ARGS}
 
-if [ ! -z $INPUT_SKIP_UNCHANGED_DIGEST ]; then
-    export DIGEST=$(cat digest)
+if [ -n "${INPUT_SKIP_UNCHANGED_DIGEST}" ]; then
+    DIGEST="$(cat /kaniko/digest)"
+    export DIGEST
+    /kaniko/crane auth login "${REGISTRY}" -u "${USERNAME}" -p "${PASSWORD}"
+    REMOTE="$(crane digest "${REGISTRY}/${REPOSITORY}:${TAG}" || true)"
+    export REMOTE
 
-    /kaniko/crane auth login $REGISTRY -u $USERNAME -p $PASSWORD
-
-    export REMOTE=$(crane digest $REGISTRY/${REPOSITORY}:latest)
-
-    if [ "$DIGEST" == "$REMOTE" ]; then
-        echo "Digest hasn't changed, skipping, $DIGEST"
-        echo "Done 🎉️"
+    if [ "${DIGEST}" = "${REMOTE}" ]; then
+        echo "Digest hasn't changed, skipping, ${DIGEST}"
+        echo "Done "
         exit 0
     fi
 
     echo "Pushing image..."
     
-    /kaniko/crane push image.tar $IMAGE
+    /kaniko/crane push image.tar "${IMAGE}"
 
-    if [ ! -z $IMAGE_LATEST ]; then
+    if [ -n "${IMAGE_LATEST}" ]; then
         echo "Tagging latest..."
-        /kaniko/crane tag $IMAGE latest  
+        /kaniko/crane tag "${IMAGE}" "${TAG}"  
     fi
  
-    echo "Done 🎉️"
+    echo "Done "
 fi


### PR DESCRIPTION
Added the following improvements to action-kaniko:
- feat: Added output variables
- fix: Improve general robustness of `entrypoint.sh`, squashing most issues with shellcheck.net
- fix: update dependencies