### PR TITLE
fix: entrypoint ARGS remove new line

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,6 +94,8 @@ EOF
 # https://github.com/GoogleContainerTools/kaniko/issues/1803
 # https://github.com/GoogleContainerTools/kaniko/issues/1349
 export IFS=''
+# Removes a trailing new line
+ARGS=$(echo "${ARGS}" | sed 's/\n*$//')
 kaniko_cmd="/kaniko/executor ${ARGS} --reproducible --force"
 echo "Running kaniko command ${kaniko_cmd}"
 eval "${kaniko_cmd}"


### PR DESCRIPTION
The PR removes a trailing new line, if any, from the `$ARGS` in the entrypoint.sh

We hit the issue in the Actions.  `kaniko/executor` command was split into two lines

 Logs example:
```sh

Line 14 Running kaniko command /kaniko/executor --cache=true --cache-repo=ghcr.io/kiwicom/dockerfiles/cache --context /github/workspace/. --dockerfile ./Dockerfile  --digest-file /kaniko/digest --image-name-tag-with-digest-file=/kaniko/image-tag-digest --destination ghcr.io/kiwicom/dockerfiles/pre-commit:3.6.2 --destination ghcr.io/kiwicom/dockerfiles/pre-commit:latest --context pre-commit --dockerfile pre-commit/Dockerfile

Line 15 --reproducible --force

....

/entrypoint.sh: eval: line 100: --reproducible: not found
```

The issue occurred after this refactoring https://github.com/aevea/action-kaniko/commit/a95ae7d70653e404655e84ccf0e177eb9e1e85bf