### PR TITLE
fix: handle multi-line image-tag-digest output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,9 @@ eval "${kaniko_cmd}"
 
 echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 echo "digest=$(cat /kaniko/digest)" >> "$GITHUB_OUTPUT"
-echo "image-tag-digest=$(cat /kaniko/image-tag-digest)" >> "$GITHUB_OUTPUT"
+echo "image-tag-digest<<EOF" >>"$GITHUB_OUTPUT"
+echo "$(cat /kaniko/image-tag-digest)" >>"$GITHUB_OUTPUT"
+echo 'EOF' >>"$GITHUB_OUTPUT"
 
 
 if [ -n "$INPUT_SKIP_UNCHANGED_DIGEST" ]; then


### PR DESCRIPTION
Fixes the issue here https://github.com/aevea/action-kaniko/issues/66

Tested this on my own fork for builds my company is doing and it works. 

Just implements what is discussed [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)